### PR TITLE
add to_s to avoid conversion error

### DIFF
--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -44,7 +44,7 @@ class Fluent::RewriteTagFilterOutput < Fluent::Output
     es.each do |time,record|
       rewrite = false
       @rewriterules.each do |index, rewritekey, regexp, rewritetag|
-        rewritevalue = record[rewritekey]
+        rewritevalue = record[rewritekey].to_s
         next if rewritevalue.nil?
         next unless (regexp && regexp.match(rewritevalue))
         backreference_table = map_regex_table($~.captures)


### PR DESCRIPTION
When I used fluent-plugin-rewrite-tag-filter after fluent-plugin-flowcounter, I got an error as following, "can't convert Fixnum to String". I think flowcounted values are integer not string.
