### PR TITLE
Added config param of use of first match tag

### DIFF
--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -3,7 +3,7 @@ class Fluent::RewriteTagFilterOutput < Fluent::Output
 
   config_param :capitalize_regex_backreference, :bool, :default => false
   config_param :remove_tag_prefix, :string, :default => nil
-  config_param :use_of_first_match_tag, :string, :default => nil
+  config_param :use_of_first_match_tag_regexp, :string, :default => nil
   config_param :hostname_command, :string, :default => 'hostname'
 
   MATCH_OPERATOR_EXCLUDE = '!'
@@ -37,8 +37,8 @@ class Fluent::RewriteTagFilterOutput < Fluent::Output
       @remove_tag_prefix = /^#{Regexp.escape(@remove_tag_prefix)}\.?/
     end
 
-    unless @use_of_first_match_tag.nil?
-      @use_of_first_match_tag = Regexp.new(@use_of_first_match_tag)
+    unless @use_of_first_match_tag_regexp.nil?
+      @use_of_first_match_tag_regexp = Regexp.new(@use_of_first_match_tag_regexp)
     end
   end
 
@@ -104,7 +104,7 @@ class Fluent::RewriteTagFilterOutput < Fluent::Output
 
   def get_placeholder(tag)
     tag = tag.sub(@remove_tag_prefix, '') if @remove_tag_prefix
-    tag = tag.match(@use_of_first_match_tag)[1] if @use_of_first_match_tag
+    tag = tag.match(@use_of_first_match_tag_regexp)[1] if @use_of_first_match_tag_regexp
     return {
       '__HOSTNAME__' => @hostname,
       '${hostname}' => @hostname,

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -55,8 +55,8 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
     rewriterule20 domain ^news\.google\.com$ site.GoogleNews
   ]
 
-  CONFIG_USE_OF_FIRST_MATCH_TAG = %[
-    use_of_first_match_tag [a-z_]+\.([a-z_]+)\.
+  CONFIG_USE_OF_FIRST_MATCH_TAG_REGEXP = %[
+    use_of_first_match_tag_regexp [a-z_]+\.([a-z_]+)\.
     rewriterule1 type ^[a-z_]+$ api.${tag}.warrior
   ]
 
@@ -194,7 +194,7 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
   end
 
   def test_emit8_first_match_tag
-    d1 = create_driver(CONFIG_USE_OF_FIRST_MATCH_TAG, 'hoge_application.production.api')
+    d1 = create_driver(CONFIG_USE_OF_FIRST_MATCH_TAG_REGEXP, 'hoge_application.production.api')
     d1.run do
       d1.emit({'user_id' => '1000', 'type' => 'warrior', 'name' => 'Richard Costner'})
     end
@@ -203,7 +203,7 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
     assert_equal 1, emits.length
     assert_equal 'api.production.warrior', emits[0][0] # tag
 
-    d2 = create_driver(CONFIG_USE_OF_FIRST_MATCH_TAG, 'hoge_application.development.api')
+    d2 = create_driver(CONFIG_USE_OF_FIRST_MATCH_TAG_REGEXP, 'hoge_application.development.api')
     d2.run do
       d2.emit({'user_id' => '1000', 'type' => 'warrior', 'name' => 'Mason Smith'})
     end


### PR DESCRIPTION
# Added new config_param.

**An proposal. :)**

Add config_param of **use_of_first_match_tag_regexp** . 
I hope use of first match tag to `${tag}`.

**How to use**
- fluentd.conf
  
  ```
  <source>
    type forward
    port 24224
  </source>
  
  <match hoge_game.*.api>
    type copy
  
    <store>
      type rewrite_tag_filter
      use_of_first_match_tag_regexp \w+\.(\w+)\.
      rewriterule1 type ^(\w+)$ api.${tag}.$1
    </store>
  
  </match>
  
  <match api.production.*>
    type file
    path /var/log/fluentd/warrior.log
  </match>
  
  <match api.development.*>
    type file
    path /var/log/fluentd/warrior-dev.log
  </match>
  ```
- fluent-cat command
  
  ```
  > echo '{"user_id": "1000", "name": "Keiji Matsuzaki", "type": "warrior"}' | bundle ex fluent-cat hoge_game.production.api
  > echo '{"user_id": "1000", "name": "Keiji Matsuzaki", "type": "warrior"}' | bundle ex fluent-cat hoge_game.development.api
  ```

**results**
- warrior.log (production)
  
  ```
  2013-10-09T18:11:26+09:00       api.production.warrior  {"user_id":"1000","name":"Richard Costner","type":"warrior"}
  ```
- warrior-dev.log
  
  ```
  2013-10-09T18:11:36+09:00       api.development.warrior {"user_id":"1000","name":"Mason Smith","type":"warrior"}
  ```
