### PR TITLE
Support split of tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ It is supporting there placeholder for new_tag(rewrited tag).
 It's available to use this placeholder with `remove_tag_prefix` option.  
 This option adds removing tag prefix for `${tag}` or `__TAG__` in placeholder.
 
-- `{$tag[0]}`
-- `{$tag[1]}`
-- `{$tag[2]}`
+- `{$tags[0]}`
+- `{$tags[1]}`
+- `{$tags[2]}`
 
 Tag placeholder is element index access can be used.
-When second tag element acccess of ```foo.bar.baz```, use ```${tag[1]}``` (bar).
-**Not support range setting ```${tag[0..2]}```**.
+When second tag element acccess of ```foo.bar.baz```, use ```${tags[1]}``` (bar).
+**Not support range setting ```${tags[0..2]}```**.
 
 - `${hostname}`
 - `__HOSTNAME__`

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -20,7 +20,7 @@ class Fluent::RewriteTagFilterOutput < Fluent::Output
         raise Fluent::ConfigError, "failed to parse rewriterules at #{key} #{conf[key]}"
       end
 
-      unless rewritetag.match(/\$\{tag\[\d\.\.\.?\d\]\}/).nil?
+      unless rewritetag.match(/\$\{tags\[\d\.\.\.?\d\]\}/).nil?
         raise Fluent::ConfigError, "${tags} placeholder does not support range specify at #{key} #{conf[key]}"
       end
 

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -78,10 +78,10 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
       d = create_driver('rewriterule1 foo foo')
     }
     assert_raise(Fluent::ConfigError) {
-      d = create_driver('rewriterule1 hoge hoge.${tag[0..2]}')
+      d = create_driver('rewriterule1 hoge hoge.${tags[0..2]}')
     }
     assert_raise(Fluent::ConfigError) {
-      d = create_driver('rewriterule1 fuga fuga.${tag[1...2]}')
+      d = create_driver('rewriterule1 fuga fuga.${tags[1...2]}')
     }
     d = create_driver %[
       rewriterule1 domain ^www.google.com$ site.Google


### PR DESCRIPTION
**Support split of tag.**

An proposal.
This difference is split tag, use of period.

``` ruby
${tag} #== hoge.fuga.moge

${tags[0]} #== hoge
${tags[1]} #== fuga
${tags[2]} #== moge
```

**fluentd.conf(sample)**

```
<source>
  type forward
  port 24244
</source>

<match app.game.*>
  type rewrite_tag_filter
  rewriterule1 server_type ^([a-z]+)$ ${tag[1]}.$1.${tag[2]}
</match>

<match game.production.api>
  type copy
  <store>
    type tdlog
    api_key hogehogehogehogehogehoge
  </store>

  <store>
    type file
    path /var/log/fluentd/production_api.log
  </store>
</match>

<match game.staging.api>
  type copy
  <store>
    type mongo
  </store>
  <store>
    type file
    path /var/log/fluentd/staging_api.log
  </store>
</match>

<match game.development.api>
  type file
  path /var/log/fluentd/development_api.log
</match>
```

**command**

```
> echo '{"user_id": "10000", "name": "hogehoge", "server_type": "development", "description": "super user"}' | bundle ex fluent-cat app.game.peach
> echo '{"user_id": "10000", "name": "hogehoge", "server_type": "production", "description": "super user"}' | bundle ex fluent-cat app.game.mario
> echo '{"user_id": "10000", "name": "hogehoge", "server_type": "staging", "description": "super user"}' | bundle ex fluent-cat app.game.luigi
```

**result**
- production_api.log

```
2013-10-11T15:25:28+09:00       game.production.mario   {"user_id":"10000","name":"hogehoge","server_type":"production","description":"super user"}
```
- staging_api.log

```
2013-10-11T15:25:48+09:00       game.staging.luigi      {"user_id":"10000","name":"hogehoge","server_type":"staging","description":"super user"}
```
- development_api.log

```
2013-10-11T15:25:08+09:00       game.development.peach  {"user_id":"10000","name":"hogehoge","server_type":"development","description":"super user"}
```
