### PR TITLE
update link text for fluentd official

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Rewrite Tags for [Fluentd](http://fluentd.org) like `mod_rewrite` [![Build Status](https://travis-ci.org/fluent/fluent-plugin-rewrite-tag-filter.png?branch=master)](https://travis-ci.org/fluent/fluent-plugin-rewrite-tag-filter)
+# fluent-plugin-rewrite-tag-filter [![Build Status](https://travis-ci.org/fluent/fluent-plugin-rewrite-tag-filter.png?branch=master)](https://travis-ci.org/fluent/fluent-plugin-rewrite-tag-filter)
 
 ## Overview
 
-### RewriteTagFilterOutput
-
-Rewrite Tag Filter is designed to rewrite [Fluentd](http://fluentd.org)([GitHub](http://github.com/fluent/fluentd)) tags like mod_rewrite.  
+Rewrite Tag Filter for [Fluentd](http://fluentd.org). It is designed to rewrite tags like mod_rewrite.  
 Re-emit the record with rewrited tag when a value matches/unmatches with a regular expression.  
 Also you can change a tag from Apache log by domain, status code (ex. 500 error),  
 user-agent, request-uri, regex-backreference and so on with regular expression.


### PR DESCRIPTION
Hi, @kiyoto 
Is it a quick and better solution to add link for fluentd official web page?
- original:
  https://github.com/fluent/fluent-plugin-rewrite-tag-filter/blob/502f80f/README.md
- current: dropping out travis ci banner
  https://github.com/fluent/fluent-plugin-rewrite-tag-filter/blob/6c0384d/README.md
- this PR
  https://github.com/fluent/fluent-plugin-rewrite-tag-filter/blob/2b5fc30/README.md
