### PR TITLE
Drop old Ruby support

### DIFF
--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -14,11 +14,6 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
 
   MATCH_OPERATOR_EXCLUDE = '!'
 
-  def initialize
-    super
-    require 'string/scrub' if RUBY_VERSION.to_f < 2.1
-  end
-
   def configure(conf)
     super
 


### PR DESCRIPTION
Because Ruby 2.0 or earlier are outdated.