### PR TITLE
Drop Fluentd v0.10.x support

### DIFF
--- a/fluent-plugin-rewrite-tag-filter.gemspec
+++ b/fluent-plugin-rewrite-tag-filter.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "test-unit", ">= 3.1.0"
   s.add_development_dependency "rake"
-  s.add_runtime_dependency "fluentd", [">= 0.10.0", "< 0.14.0"]
+  s.add_runtime_dependency "fluentd", [">= 0.12.0", "< 0.14.0"]
 end

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -1,11 +1,6 @@
 class Fluent::RewriteTagFilterOutput < Fluent::Output
   Fluent::Plugin.register_output('rewrite_tag_filter', self)
 
-  # To support Fluentd v0.10.57 or earlier
-  unless method_defined?(:router)
-    define_method("router") { Fluent::Engine }
-  end
-
   # For fluentd v0.12.16 or earlier
   class << self
     unless method_defined?(:desc)
@@ -35,11 +30,6 @@ class Fluent::RewriteTagFilterOutput < Fluent::Output
   end
 
   MATCH_OPERATOR_EXCLUDE = '!'
-
-  # Define `log` method for v0.10.42 or earlier
-  unless method_defined?(:log)
-    define_method("log") { $log }
-  end
 
   def initialize
     super


### PR DESCRIPTION
Because Fluentd v0.10.x already has been EOL.