### PR TITLE
Update example

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -2,15 +2,17 @@
 
 # appearing plugins:
 #  rewrite_tag_filter: http://rubygems.org/gems/fluent-plugin-rewrite-tag-filter
-#  forest: http://rubygems.org/gems/fluent-plugin-forest
 #  datacounter: http://rubygems.org/gems/fluent-plugin-datacounter
 #  growthforecast: http://rubygems.org/gems/fluent-plugin-growthforecast
 
 <source>
-  type tail
+  @type tail
   path /var/log/httpd/access_log
-  format /^(?<domain>[^ ]*) (?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<status>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<response_time>[^ ]*))?$/
-  time_format %d/%b/%Y:%H:%M:%S %z
+  <parse>
+    @type regexp
+    expression /^(?<domain>[^ ]*) (?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<status>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<response_time>[^ ]*))?$/
+    time_format %d/%b/%Y:%H:%M:%S %z
+  </parse>
   tag td.apache.access
   pos_file /var/log/td-agent/apache_access.pos
 </source>
@@ -18,139 +20,173 @@
 
 # Extract specified virtual domain
 <match td.apache.access>
-  type copy
+  @type copy
   <store>
-    type rewrite_tag_filter
+    @type rewrite_tag_filter
     capitalize_regex_backreference yes
-    rewriterule1 domain ^(maps|news|mail)\.google\.com$ site.Google$1
+    <rule>
+      key domain
+      pattern /^(maps|news|mail)\.google\.com$/
+      tag site.Google$1
+    </rule>
   </store>
   <store>
-    type rewrite_tag_filter
+    @type rewrite_tag_filter
     capitalize_regex_backreference yes
-    rewriterule1 domain ^(maps)\.google\.com$ sitepath.Google$1
+    <rule>
+      key domain
+      pattern /^(maps)\.google\.com$/
+      tag sitepath.Google$1
+    </rule>
   </store>
 </match>
 
 
 # Second level analyzing
 <match sitepath.GoogleMaps>
+  @type copy
   <store>
-    type rewrite_tag_filter
-    rewriterule1 path ^/labs site.GoogleMaps.Labs
-    rewriterule2 path ^/static/\d+ site.GoogleMaps.Static
-    rewriterule3 path ^/help/maps/(streetview|getmaps) site.GoogleMaps.Help
+    @type rewrite_tag_filter
+    <rule>
+      key path
+      pattern /^\/labs/
+      tag site.GoogleMaps.Labs
+    </rule>
+    <rule>
+      key path
+      pattern /^\/static/\d+/
+      tag site.GoogleMaps.Static
+    </rule>
+    <rule>
+      key path
+      pattern /^\/help\/maps\/(streetview|getmaps)/
+      tag site.GoogleMaps.Help
+    </rule>
   </store>
   <store>
-    type rewrite_tag_filter
-    rewriterule1 referer headlines\.yahoo\.co\.jp site.GoogleMaps.referer_YahooHeadlines
-    rewriterule2 referer news\.livedoor\.com site.GoogleMaps.referer_LivedoorNews
+    @type rewrite_tag_filter
+    <rule>
+      key referer
+      pattern /headlines\.yahoo\.co\.jp/
+      tag site.GoogleMaps.referer_YahooHeadlines
+    </rule>
+    <rule>
+      key referer
+      pattern /news\.livedoor\.com/
+      tag site.GoogleMaps.referer_LivedoorNews
+    </rule>
   </store>
   <store>
-    type rewrite_tag_filter
-    rewriterule1 agent Googlebot/ site.GoogleMaps.agent_Googlebot
-    rewriterule2 agent ^.* iPhone .+Googlebot-Mobile/.*$ site.GoogleMaps.agent_GooglebotSmartphone
-    rewriterule3 agent Googlebot-Mobile/ site.GoogleMaps.agent_GooglebotMobile
-    rewriterule4 agent bingbot site.GoogleMaps.agent_Bingbot
-    rewriterule5 agent Baiduspider site.GoogleMaps.agent_Baiduspider
+    @type rewrite_tag_filter
+    <rule>
+      key agent
+      pattern /Googlebot\//
+      tag site.GoogleMaps.agent_Googlebot
+    </rule>
+    <rule>
+      key agent
+      pattern /^.* iPhone .+Googlebot-Mobile\/.*$/
+      tag site.GoogleMaps.agent_GooglebotSmartphone
+    </rule>
+    <rule>
+      key agent
+      pattern /Googlebot-Mobile\//
+      tag site.GoogleMaps.agent_GooglebotMobile
+    </rule>
+    <rule>
+      key agent
+      pattern /bingbot/
+      tag site.GoogleMaps.agent_Bingbot
+    </rule>
+    <rule>
+      key agent
+      pattern /Baiduspider/
+      tag site.GoogleMaps.agent_Baiduspider
+    </rule>
   </store>
 </match>
 
 
 # Summarize
 <match site.**>
-  type copy
+  @type copy
   <store>
-    type forest
-    subtype datacounter
-    <template>
-      unit minute
-      count_key response_time
-      outcast_unmatched false
-      aggregate all
-      tag gf.responsetime.__TAG__
-      pattern1 0-100msec ^\d{1,5}$
-      pattern2 100-300msec ^[1-2]\d{5}$
-      pattern3 300-600msec ^[3-5]\d{5}$
-      pattern4 600msec-1sec ^[6-9]\d{5}$
-      pattern5 1-2sec ^1\d{6}$
-      pattern6 2-10sec ^[2-9]\d{6}$
-      pattern7 10sec_over ^\d{8,}$
-    </template>
+    @type datacounter
+    unit minute
+    count_key response_time
+    outcast_unmatched false
+    aggregate tag
+    tag_prefix gf.responsetime
+    output_per_tag yes
+    pattern1 0-100msec ^\d{1,5}$
+    pattern2 100-300msec ^[1-2]\d{5}$
+    pattern3 300-600msec ^[3-5]\d{5}$
+    pattern4 600msec-1sec ^[6-9]\d{5}$
+    pattern5 1-2sec ^1\d{6}$
+    pattern6 2-10sec ^[2-9]\d{6}$
+    pattern7 10sec_over ^\d{8,}$
   </store>
   <store>
-    type forest
-    subtype datacounter
-    <template>
-      unit minute
-      outcast_unmatched false
-      aggregate all
-      tag gf.responsecode.__TAG__
-      count_key status
-      pattern1 200 ^200$
-      pattern2 2xx ^2\d\d$
-      pattern3 301 ^301$
-      pattern4 302 ^302$
-      pattern5 3xx ^3\d\d$
-      pattern6 403 ^403$
-      pattern7 404 ^404$
-      pattern8 410 ^410$
-      pattern9 4xx ^4\d\d$
-      pattern10 500 ^5\d\d$
-    </template>
+    @type datacounter
+    unit minute
+    outcast_unmatched false
+    aggregate tag
+    tag_prefix gf.responsecode
+    output_per_tag yes
+    count_key status
+    pattern1 200 ^200$
+    pattern2 2xx ^2\d\d$
+    pattern3 301 ^301$
+    pattern4 302 ^302$
+    pattern5 3xx ^3\d\d$
+    pattern6 403 ^403$
+    pattern7 404 ^404$
+    pattern8 410 ^410$
+    pattern9 4xx ^4\d\d$
+    pattern10 500 ^5\d\d$
   </store>
   <store>
-    type forest
-    subtype datacounter
-    <template>
-      unit minute
-      count_key agent
-      outcast_unmatched false
-      aggregate all
-      tag gf.useragent.__TAG__
-      pattern1 api HttpRequest
-      pattern2 robot (spider|bot|crawler|\+http\:)
-      pattern3 smartphone (iPhone|iPod|Android|dream|CUPCAKE|blackberry|webOS|incognito|webmate|IEMobile)
-      pattern4 mobile (^KDDI|UP.Browser|DoCoMo|Vodafone|SoftBank|WILLCOM)
-      pattern5 pc .+
-    </template>
+    @type datacounter
+    unit minute
+    count_key agent
+    outcast_unmatched false
+    aggregate tag
+    tag_prefix gf.useragent
+    output_per_tag yes
+    pattern1 api HttpRequest
+    pattern2 robot (spider|bot|crawler|\+http\:)
+    pattern3 smartphone (iPhone|iPod|Android|dream|CUPCAKE|blackberry|webOS|incognito|webmate|IEMobile)
+    pattern4 mobile (^KDDI|UP.Browser|DoCoMo|Vodafone|SoftBank|WILLCOM)
+    pattern5 pc .+
   </store>
 </match>
 
 
 # Graph
 <match gf.responsetime.**>
-  type forest
-  subtype growthforecast
+  @type growthforecast
   remove_prefix gf.responsetime.site
-  <template>
-    gfapi_url http://localhost:5125/api/
-    service   __TAG__
-    section   response_time
-    name_keys 0-100msec_percentage,100-300msec_percentage,300-600msec_percentage,600msec-1sec_percentage,1-2sec_percentage,2-10sec_percentage,10sec_over_percentage
-  </template>
+  gfapi_url http://localhost:5125/api/
+  tag_for   service
+  section   response_time
+  name_keys 0-100msec_percentage,100-300msec_percentage,300-600msec_percentage,600msec-1sec_percentage,1-2sec_percentage,2-10sec_percentage,10sec_over_percentage
 </match>
 
 <match gf.responsecode.**>
-  type forest
-  subtype growthforecast
+  @type growthforecast
   remove_prefix gf.responsecode.site
-  <template>
-    gfapi_url http://localhost:5125/api/
-    service   __TAG__
-    section   response_code
-    name_keys 301_count,302_count,3xx_count,403_count,404_count,410_count,4xx_count,500_count
-  </template>
+  gfapi_url http://localhost:5125/api/
+  tag_for   service
+  section   response_code
+  name_keys 301_count,302_count,3xx_count,403_count,404_count,410_count,4xx_count,500_count
 </match>
 
 <match gf.useragent.**>
-  type forest
-  subtype growthforecast
+  @type growthforecast
   remove_prefix gf.useragent.site
-  <template>
-    gfapi_url http://localhost:5125/api/
-    service   __TAG__
-    section   useragent
-    name_keys pc_count,mobile_count,smartphone_count,robot_count,api_count
-  </template>
+  gfapi_url http://localhost:5125/api/
+  tag_for   service
+  section   useragent
+  name_keys pc_count,mobile_count,smartphone_count,robot_count,api_count
 </match>
 

--- a/example2.conf
+++ b/example2.conf
@@ -7,10 +7,13 @@
 #  growthforecast: http://rubygems.org/gems/fluent-plugin-growthforecast
 
 <source>
-  type tail
+  @type tail
   path /var/log/httpd/access_log
-  format /^(?<domain>[^ ]*) (?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<status>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<response_time>[^ ]*))?$/
-  time_format %d/%b/%Y:%H:%M:%S %z
+  <parse>
+    @type regexp
+    expression /^(?<domain>[^ ]*) (?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<status>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<response_time>[^ ]*))?$/
+    time_format %d/%b/%Y:%H:%M:%S %z
+  </parse>
   tag td.apache.access
   pos_file /var/log/td-agent/apache_access.pos
 </source>
@@ -18,60 +21,83 @@
 
 # Extract specified virtual domain
 <match td.apache.access>
-  type rewrite_tag_filter
-  rewriterule1 domain ^maps\.google\.com$ filter.GoogleMap
+  @type rewrite_tag_filter
+  <rule>
+    key domain
+    pattern /^maps\.google\.com$/
+    tag filter.GoogleMap
+  </rule>
 </match>
 
 
 # Filtering
 <match filter.GoogleMap>
-  type rewrite_tag_filter
-  rewriterule1 path ^/(img|css|js|static|assets)/ clear
-  rewriterule2 status ^(?!200)$ clear
-  rewriterule3 method ^(?!GET)$ clear
-  rewriterule4 agent (spider|bot|crawler|\+http\:) clear
-  rewriterule5 path ^/(admin|api|backend) site.GoogleMap.backend
-  rewriterule6 path .+ site.GoogleMap.front
+  @type rewrite_tag_filter
+  <rule>
+    key path
+    pattern /^\/(img|css|js|static|assets)\//
+    tag clear
+  </rule>
+  <rule>
+    key status
+    pattern /^(?!200)$/
+    tag clear
+  </rule>
+  <rule>
+    key method
+    pattern /^(?!GET)$/
+    tag clear
+  </rule>
+  <rule>
+    key agent
+    pattern /(spider|bot|crawler|\+http\:)/
+    tag clean
+  </rule>
+  <rule>
+    key path
+    pattern /^\/(admin|api|backend)/
+    tag site.GoogleMap.backend
+  </rule>
+  <rule>
+    key path
+    pattern /.+/
+    tag site.GoogleMap.front
+  </rule>
 </match>
 
 
 # Summarize
 <match site.**>
-  type forest
-  subtype datacounter
-  <template>
-    unit minute
-    count_key response_time
-    outcast_unmatched false
-    aggregate all
-    tag gf.responsetime.__TAG__
-    pattern1 0-100msec ^\d{1,5}$
-    pattern2 100-300msec ^[1-2]\d{5}$
-    pattern3 300-600msec ^[3-5]\d{5}$
-    pattern4 600msec-1sec ^[6-9]\d{5}$
-    pattern5 1-2sec ^1\d{6}$
-    pattern6 2-10sec ^[2-9]\d{6}$
-    pattern7 10sec_over ^\d{8,}$
-  </template>
+  @type datacounter
+  unit minute
+  count_key response_time
+  outcast_unmatched false
+  aggregate tag
+  tag_prefix gf.responsetime
+  output_per_tag yes
+  pattern1 0-100msec ^\d{1,5}$
+  pattern2 100-300msec ^[1-2]\d{5}$
+  pattern3 300-600msec ^[3-5]\d{5}$
+  pattern4 600msec-1sec ^[6-9]\d{5}$
+  pattern5 1-2sec ^1\d{6}$
+  pattern6 2-10sec ^[2-9]\d{6}$
+  pattern7 10sec_over ^\d{8,}$
 </match>
 
 
 # Graph
 <match gf.responsetime.**>
-  type forest
-  subtype growthforecast
+  @type growthforecast
   remove_prefix gf.responsetime.site
-  <template>
-    gfapi_url http://localhost:5125/api/
-    service   __TAG__
-    section   response_time
-    name_keys 0-100msec_percentage,100-300msec_percentage,300-600msec_percentage,600msec-1sec_percentage,1-2sec_percentage,2-10sec_percentage,10sec_over_percentage
-  </template>
+  gfapi_url http://localhost:5125/api/
+  tag_for   service
+  section   response_time
+  name_keys 0-100msec_percentage,100-300msec_percentage,300-600msec_percentage,600msec-1sec_percentage,1-2sec_percentage,2-10sec_percentage,10sec_over_percentage
 </match>
 
 
 # Clear tag
 <match clear>
-  type null
+  @type null
 </match>
 


### PR DESCRIPTION
* Stop using fluent-plugin-forest
* Use `<rule>` section instead of `rewriterule<N>`
* Use `<parse>` section instead of `format` parameter
* Use `@type` parameter instead of `type` parameter

Close #65 