### PR TITLE
Add a new parameter emit_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For more details, see [Plugin Management](https://docs.fluentd.org/v0.14/article
 * **remove_tag_prefix** (string) (optional): Remove tag prefix for tag placeholder. (see the section of "Tag placeholder")
 * **hostname_command** (string) (optional): Override hostname command for placeholder. (see the section of "Tag placeholder")
   * Default value: `hostname`
-* **emit_mode** (enum) (required): Specify emit_mode to `record` or `batch`. `record` will emit events per record. `batch` will emit events per rewritten tag.
+* **emit_mode** (enum) (required): Specify emit_mode to `record` or `batch`. `record` will emit events per record. `batch` will emit events per rewritten tag, and decrease IO.
   * Default value: `record`
 
 ### \<rule\> section (optional) (multiple)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ For more details, see [Plugin Management](https://docs.fluentd.org/v0.14/article
 * **remove_tag_prefix** (string) (optional): Remove tag prefix for tag placeholder. (see the section of "Tag placeholder")
 * **hostname_command** (string) (optional): Override hostname command for placeholder. (see the section of "Tag placeholder")
   * Default value: `hostname`
-* **emit_mode** (enum) (required): Specify emit_mode to `record` or `batch`. `record` will emit events per record. `batch` will emit events per rewritten tag, and decrease IO.
-  * Default value: `record`
+* **emit_mode** (enum) (required): Specify emit_mode to `batch` or `record`. `batch` will emit events per rewritten tag, and decrease IO. `record` will emit events per record.
+  * Default value: `batch`
 
 ### \<rule\> section (optional) (multiple)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ For more details, see [Plugin Management](https://docs.fluentd.org/v0.14/article
   * Default value: no
 * **remove_tag_prefix** (string) (optional): Remove tag prefix for tag placeholder. (see the section of "Tag placeholder")
 * **hostname_command** (string) (optional): Override hostname command for placeholder. (see the section of "Tag placeholder")
-  * Default value: `hostname`.
+  * Default value: `hostname`
+* **emit_mode** (enum) (required): Specify emit_mode to `record` or `batch`. `record` will emit events per record. `batch` will emit events per rewritten tag.
+  * Default value: `record`
 
 ### \<rule\> section (optional) (multiple)
 

--- a/fluent-plugin-rewrite-tag-filter.gemspec
+++ b/fluent-plugin-rewrite-tag-filter.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "test-unit", ">= 3.1.0"
+  s.add_development_dependency "test-unit-rr"
   s.add_development_dependency "rake"
   s.add_runtime_dependency "fluentd", [">= 0.14.2", "< 2"]
   s.add_runtime_dependency "fluent-config-regexp-type"

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -13,7 +13,7 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
   desc 'Override hostname command for placeholder.'
   config_param :hostname_command, :string, :default => 'hostname'
   desc "The emit mode. If `batch`, this plugin will emit events per rewritten tag."
-  config_param :emit_mode, :enum, list: [:record, :batch], default: :record
+  config_param :emit_mode, :enum, list: [:record, :batch], default: :batch
 
   config_section :rule, param_name: :rules, multi: true do
     desc "The field name to which the regular expression is applied"

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -12,8 +12,8 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
   config_param :remove_tag_prefix, :string, :default => nil
   desc 'Override hostname command for placeholder.'
   config_param :hostname_command, :string, :default => 'hostname'
-  desc "Emit mode"
-  config_param :emit_mode, :enum, list: [:record, :stream], default: :record
+  desc "The emit mode. If `batch`, this plugin will emit events per rewritten tag."
+  config_param :emit_mode, :enum, list: [:record, :batch], default: :record
 
   config_section :rule, param_name: :rules, multi: true do
     desc "The field name to which the regular expression is applied"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,9 +1,13 @@
 require 'bundler/setup'
 require 'test/unit'
+require 'test/unit/rr'
 
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 $LOAD_PATH.unshift(__dir__)
 require 'fluent/test'
 require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
+
+Test::Unit::TestCase.include(Fluent::Test::Helpers)
 
 require 'fluent/plugin/out_rewrite_tag_filter'

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -310,6 +310,7 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
     sub_test_case "emit_mode" do
       test "record" do
         conf = %[
+          emit_mode record
           <rule>
             key key
             pattern /^(odd|even)$/

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -321,21 +321,21 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
         mock.proxy(d.instance.router).emit(anything, anything, anything).times(6)
         mock.proxy(d.instance.router).emit_stream(anything, anything).times(0)
         d.run(default_tag: "input") do
-          d.feed([[time, { "key" => "odd", "message": "message-1" }],
-                  [time, { "key" => "even", "message": "message-2" }],
-                  [time, { "key" => "odd", "message": "message-3" }],
-                  [time, { "key" => "even", "message": "message-4" }],
-                  [time, { "key" => "odd", "message": "message-5" }],
-                  [time, { "key" => "even", "message": "message-6" }]])
+          d.feed([[time, { "key" => "odd", "message" => "message-1" }],
+                  [time, { "key" => "even", "message" => "message-2" }],
+                  [time, { "key" => "odd", "message" => "message-3" }],
+                  [time, { "key" => "even", "message" => "message-4" }],
+                  [time, { "key" => "odd", "message" => "message-5" }],
+                  [time, { "key" => "even", "message" => "message-6" }]])
         end
         events = d.events
         expected_events = [
-          ["odd", time, { "key" => "odd", "message": "message-1" }],
-          ["even", time, { "key" => "even", "message": "message-2" }],
-          ["odd", time, { "key" => "odd", "message": "message-3" }],
-          ["even", time, { "key" => "even", "message": "message-4" }],
-          ["odd", time, { "key" => "odd", "message": "message-5" }],
-          ["even", time, { "key" => "even", "message": "message-6" }],
+          ["odd", time, { "key" => "odd", "message" => "message-1" }],
+          ["even", time, { "key" => "even", "message" => "message-2" }],
+          ["odd", time, { "key" => "odd", "message" => "message-3" }],
+          ["even", time, { "key" => "even", "message" => "message-4" }],
+          ["odd", time, { "key" => "odd", "message" => "message-5" }],
+          ["even", time, { "key" => "even", "message" => "message-6" }],
         ]
         assert_equal(events, expected_events)
       end
@@ -354,21 +354,21 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
         mock.proxy(d.instance.router).emit(anything, anything, anything).times(0)
         mock.proxy(d.instance.router).emit_stream(anything, anything).times(2)
         d.run(default_tag: "input") do
-          d.feed([[time, { "key" => "odd", "message": "message-1" }],
-                  [time, { "key" => "even", "message": "message-2" }],
-                  [time, { "key" => "odd", "message": "message-3" }],
-                  [time, { "key" => "even", "message": "message-4" }],
-                  [time, { "key" => "odd", "message": "message-5" }],
-                  [time, { "key" => "even", "message": "message-6" }]])
+          d.feed([[time, { "key" => "odd", "message" => "message-1" }],
+                  [time, { "key" => "even", "message" => "message-2" }],
+                  [time, { "key" => "odd", "message" => "message-3" }],
+                  [time, { "key" => "even", "message" => "message-4" }],
+                  [time, { "key" => "odd", "message" => "message-5" }],
+                  [time, { "key" => "even", "message" => "message-6" }]])
         end
         events = d.events
         expected_records = [
-          ["odd", time, { "key" => "odd", "message": "message-1" }],
-          ["odd", time, { "key" => "odd", "message": "message-3" }],
-          ["odd", time, { "key" => "odd", "message": "message-5" }],
-          ["even", time, { "key" => "even", "message": "message-2" }],
-          ["even", time, { "key" => "even", "message": "message-4" }],
-          ["even", time, { "key" => "even", "message": "message-6" }],
+          ["odd", time, { "key" => "odd", "message" => "message-1" }],
+          ["odd", time, { "key" => "odd", "message" => "message-3" }],
+          ["odd", time, { "key" => "odd", "message" => "message-5" }],
+          ["even", time, { "key" => "even", "message" => "message-2" }],
+          ["even", time, { "key" => "even", "message" => "message-4" }],
+          ["even", time, { "key" => "even", "message" => "message-6" }],
         ]
         assert_equal(events, expected_records)
       end

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -340,9 +340,9 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
         assert_equal(events, expected_events)
       end
 
-      test "stream" do
+      test "batch" do
         conf = %[
-          emit_mode stream
+          emit_mode batch
           <rule>
             key key
             pattern /^(odd|even)$/

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -306,5 +306,72 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
                    log.slice(/\[trace\]: (.+)$/, 1))
       assert_equal "com.example", events[0][0]
     end
+
+    sub_test_case "emit_mode" do
+      test "record" do
+        conf = %[
+          <rule>
+            key key
+            pattern /^(odd|even)$/
+            tag $1
+          </rule>
+        ]
+        time = event_time
+        d = create_driver(conf)
+        mock.proxy(d.instance.router).emit(anything, anything, anything).times(6)
+        mock.proxy(d.instance.router).emit_stream(anything, anything).times(0)
+        d.run(default_tag: "input") do
+          d.feed([[time, { "key" => "odd", "message": "message-1" }],
+                  [time, { "key" => "even", "message": "message-2" }],
+                  [time, { "key" => "odd", "message": "message-3" }],
+                  [time, { "key" => "even", "message": "message-4" }],
+                  [time, { "key" => "odd", "message": "message-5" }],
+                  [time, { "key" => "even", "message": "message-6" }]])
+        end
+        events = d.events
+        expected_events = [
+          ["odd", time, { "key" => "odd", "message": "message-1" }],
+          ["even", time, { "key" => "even", "message": "message-2" }],
+          ["odd", time, { "key" => "odd", "message": "message-3" }],
+          ["even", time, { "key" => "even", "message": "message-4" }],
+          ["odd", time, { "key" => "odd", "message": "message-5" }],
+          ["even", time, { "key" => "even", "message": "message-6" }],
+        ]
+        assert_equal(events, expected_events)
+      end
+
+      test "stream" do
+        conf = %[
+          emit_mode stream
+          <rule>
+            key key
+            pattern /^(odd|even)$/
+            tag $1
+          </rule>
+        ]
+        time = event_time
+        d = create_driver(conf)
+        mock.proxy(d.instance.router).emit(anything, anything, anything).times(0)
+        mock.proxy(d.instance.router).emit_stream(anything, anything).times(2)
+        d.run(default_tag: "input") do
+          d.feed([[time, { "key" => "odd", "message": "message-1" }],
+                  [time, { "key" => "even", "message": "message-2" }],
+                  [time, { "key" => "odd", "message": "message-3" }],
+                  [time, { "key" => "even", "message": "message-4" }],
+                  [time, { "key" => "odd", "message": "message-5" }],
+                  [time, { "key" => "even", "message": "message-6" }]])
+        end
+        events = d.events
+        expected_records = [
+          ["odd", time, { "key" => "odd", "message": "message-1" }],
+          ["odd", time, { "key" => "odd", "message": "message-3" }],
+          ["odd", time, { "key" => "odd", "message": "message-5" }],
+          ["even", time, { "key" => "even", "message": "message-2" }],
+          ["even", time, { "key" => "even", "message": "message-4" }],
+          ["even", time, { "key" => "even", "message": "message-6" }],
+        ]
+        assert_equal(events, expected_records)
+      end
+    end
   end
 end


### PR DESCRIPTION
Records in an event stream will be grouped by rewritten tag when
`emit_mode` is `stream`. This will reduce IO cost.

Fix #80