### PR TITLE
Add the option to use a regexp in remove_tag_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Rewrite Tag Filter for [Fluentd](http://fluentd.org). It is designed to rewrite tags like mod_rewrite.  
-Re-emit the record with rewrited tag when a value matches/unmatches with a regular expression.  
+Re-emit the record with rewritten tag when a value matches/unmatches with a regular expression.  
 Also you can change a tag from Apache log by domain, status code (ex. 500 error),  
 user-agent, request-uri, regex-backreference and so on with regular expression.
 
@@ -39,7 +39,7 @@ For more details, see [Plugin Management](https://docs.fluentd.org/deployment/pl
   * Obsoleted: Use \<rule\> section
 * **capitalize_regex_backreference** (bool) (optional): Capitalize letter for every matched regex backreference. (ex: maps -> Maps) for more details, see usage.
   * Default value: no
-* **remove_tag_prefix** (string) (optional): Remove tag prefix for tag placeholder. (see the section of "Tag placeholder")
+* **remove_tag_prefix** (string or regexp) (optional): Remove tag prefix for tag placeholder. (see the section of "Tag placeholder")
 * **hostname_command** (string) (optional): Override hostname command for placeholder. (see the section of "Tag placeholder")
   * Default value: `hostname`
 * **emit_mode** (enum) (required): Specify emit_mode to `batch` or `record`. `batch` will emit events per rewritten tag, and decrease IO. `record` will emit events per record.
@@ -200,7 +200,7 @@ When original tag is `kubernetes.var.log`, this will be converted to `default.ku
 
 ### Tag placeholder
 
-It is supported these placeholder for new_tag (rewrited tag).
+These placeholder values are supported for new_tag (rewritten tag).
 
 - `${tag}`
 - `__TAG__`
@@ -214,11 +214,14 @@ For example with `td.apache.access` tag, it will get `td` by `${tag_parts[0]}` a
 
 **Note** Currently, range expression ```${tag_parts[0..2]}``` is not supported.
 
-#### Placeholder Option
+#### Placeholder Options
 
 * `remove_tag_prefix`  
 
-This option adds removing tag prefix for `${tag}` or `__TAG__` in placeholder.
+The value of this option is a tag prefix that shall be removed from the final
+`${tag}` or `__TAG__` placeholder. This option takes either string values
+(e.g. `input.apache`) or regexp values which must be enclosed in forward
+slashes (e.g. `/input\.(apache|nginx)/`). 
 
 * `hostname_command` 
 
@@ -228,48 +231,62 @@ It comes short hostname with `hostname_command hostname -s` configuration specif
 
 #### Placeholder Usage
 
-It's a sample to rewrite a tag with placeholder.
+Here's a sample to rewrite a tag using the placeholder.
 
 ```
-# It will get "rewrited.access.ExampleMail"
+# This will rewrite the tag to "rewritten.access.ExampleMail"
 <match apache.access>
   @type rewrite_tag_filter
+  capitalize_regex_backreference true
   remove_tag_prefix apache
   <rule>
     key     domain
     pattern ^(mail)\.(example)\.com$
-    tag     rewrited.${tag}.$2$1
+    tag     rewritten.${tag}.$2$1
   </rule>
 </match>
 
-# It will get "rewrited.ExampleMail.app30-124.foo.com" when hostname is "app30-124.foo.com"
+# This will rewrite the tag to "rewritten.ExampleMail.app30-124.foo.com" when hostname is "app30-124.foo.com"
 <match apache.access>
   @type rewrite_tag_filter
+  capitalize_regex_backreference true
   <rule>
     key     domain
     pattern ^(mail)\.(example)\.com$
-    tag     rewrited.$2$1.${hostname}
+    tag     rewritten.$2$1.${hostname}
   </rule>
 </match>
 
-# It will get "rewrited.ExampleMail.app30-124" when hostname is "app30-124.foo.com"
+# This will rewrite the tag to "rewritten.ExampleMail.app30-124" when hostname is "app30-124.foo.com"
 <match apache.access>
   @type rewrite_tag_filter
   hostname_command hostname -s
+  capitalize_regex_backreference true
   <rule>
     key     domain
     pattern ^(mail)\.(example)\.com$
-    tag     rewrited.$2$1.${hostname}
+    tag     rewritten.$2$1.${hostname}
   </rule>
 </match>
 
-# It will get "rewrited.game.pool"
+# This will rewrite the tag to "rewritten.game.pool"
 <match app.game.pool.activity>
   @type rewrite_tag_filter
   <rule>
     key     domain
     pattern ^.+$
-    tag     rewrited.${tag_parts[1]}.${tag_parts[2]}
+    tag     rewritten.${tag_parts[1]}.${tag_parts[2]}
+  </rule>
+</match>
+
+# This will rewrite the tag to "http.access.log", using a regexp in `remove_tag_prefix`.
+<match input.{apache,nginx}.access.log>
+  @type rewrite_tag_filter
+  remove_tag_prefix /input\.(apache|nginx)/
+  <rule>
+    key     domain
+    pattern ^.+$
+    tag     http.${tag}
   </rule>
 </match>
 ```

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -59,7 +59,11 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
     end
 
     unless @remove_tag_prefix.nil?
-      @remove_tag_prefix = /^#{Regexp.escape(@remove_tag_prefix)}\.?/
+      if @remove_tag_prefix.start_with?("/") and @remove_tag_prefix.end_with?("/")
+        @remove_tag_prefix = Regexp::new('^' + @remove_tag_prefix[1..-2] + '\.?')
+      else
+        @remove_tag_prefix = /^#{Regexp.escape(@remove_tag_prefix)}\.?/
+      end
     end
 
     @batch_mode = @emit_mode == :batch

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -59,7 +59,7 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
     end
 
     unless @remove_tag_prefix.nil?
-      if @remove_tag_prefix.start_with?("/") and @remove_tag_prefix.end_with?("/")
+      if @remove_tag_prefix.start_with?('/') and @remove_tag_prefix.end_with?('/')
         @remove_tag_prefix = Regexp::new('^' + @remove_tag_prefix[1..-2] + '\.?')
       else
         @remove_tag_prefix = /^#{Regexp.escape(@remove_tag_prefix)}\.?/
@@ -156,4 +156,3 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
     return result
   end
 end
-

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -59,7 +59,7 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
     end
 
     unless @remove_tag_prefix.nil?
-      if @remove_tag_prefix.start_with?('/') and @remove_tag_prefix.end_with?('/')
+      if @remove_tag_prefix.start_with?('/') && @remove_tag_prefix.end_with?('/')
         @remove_tag_prefix = Regexp::new('^' + @remove_tag_prefix[1..-2] + '\.?')
       else
         @remove_tag_prefix = /^#{Regexp.escape(@remove_tag_prefix)}\.?/


### PR DESCRIPTION
The `remove_tag_prefix` now accepts a regexp, which must be enclosed in forward slashes (e.g. `/input\.(apache|nginx)/`. If not enclosed in slashes, the value is treated as a string, preserving compatibility with current behavior.

This is useful when we want to remove a tag prefix from a wider set of tags that we match on, e.g. this configuration:
```
<match docker.apache.*.*>
    @type rewrite_tag_filter
    remove_tag_prefix docker.apache
    <rule>
      key message
      pattern /.*/
      tag docker.${tag}
    </rule>
</match>

<match docker.nginx.*.*>
    @type rewrite_tag_filter
    remove_tag_prefix docker.nginx
    <rule>
      key message
      pattern /.*/
      tag docker.${tag}
    </rule>
</match>
```
can now be written in a more efficient form:
```
<match docker.{apache,nginx}.*.*>
    @type rewrite_tag_filter
    remove_tag_prefix /docker\.(apache|nginx)/
    <rule>
      key message
      pattern /.*/
      tag docker.${tag}
    </rule>
</match>
```

The tests and docs were updated accordingly. I'm very new to Ruby, so please be patient with the code style and feel free to suggest improvements :slightly_smiling_face: 