### PR TITLE
Add ability to specify label in rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For more details, see [Plugin Management](https://docs.fluentd.org/deployment/pl
   `/regexp/` is preferred because `/regexp/` style can support character classes such as `/[a-z]/`.
   The pattern without slashes will cause errors if you use patterns start with character classes.
 * **tag** (string) (required): New tag
+* **label** (string) (optional): New label. If specified, label can be changed per-rule.
 * **invert** (bool) (optional): If true, rewrite tag when unmatch pattern
   * Default value: `false`
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,35 @@ It's a sample to rewrite a tag with placeholder.
 </match>
 ```
 
+### Altering Labels
+
+In addition to changing tags, you can also change event's route by setting
+ the label for the re-emitted event.
+
+For example, given this configuration:
+
+```
+<match apache.access>
+  @type rewrite_tag_filter
+  <rule>
+    key     domain
+    pattern ^www\.example\.com$
+    tag     web.${tag}
+  </rule>
+  <rule>
+    key     domain
+    pattern ^(.*)\.example\.com$
+    tag     other.$1
+    label   other
+  </rule>
+</match>
+```
+
+message: `{"domain": "www.example.com"}` will get its tag changed to 
+`web.apache.access`, while message 
+`{"domain": "api.example.com"}` will get its tag changed to `other.api` and
+ be sent to label `other`
+
 ## Example
 
 - Example1: how to analyze response_time, response_code and user_agent for each virtual domain websites.  

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -79,10 +79,10 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
 
   def get_router(tgt_label)
     label_router = if tgt_label.nil? || tgt_label.empty?
-            router
-        else
-            event_emitter_router(tgt_label)
-        end
+        router
+    else
+        event_emitter_router(tgt_label)
+    end
     #log.trace "Got router for #{tgt_label}: #{!label_router.nil?}"
     return label_router
   end

--- a/lib/fluent/plugin/out_rewrite_tag_filter.rb
+++ b/lib/fluent/plugin/out_rewrite_tag_filter.rb
@@ -24,6 +24,8 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
     config_param :pattern, :regexp
     desc "New tag"
     config_param :tag, :string
+    desc "New label. If specified, label can be changed per-rule."
+    config_param :label, :string, default: nil
     desc "If true, rewrite tag when unmatch pattern"
     config_param :invert, :bool, default: false
   end
@@ -43,7 +45,7 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
       end
 
       invert = rule.invert ? MATCH_OPERATOR_EXCLUDE : ""
-      @rewriterules.push([record_accessor_create(rule.key), rule.pattern, invert, rule.tag])
+      @rewriterules.push([record_accessor_create(rule.key), rule.pattern, invert, rule.tag, rule.label])
       rewriterule_names.push(rule.key + invert + rule.pattern.to_s)
       log.info "adding rewrite_tag_filter rule: #{rule.key} #{@rewriterules.last}"
     end
@@ -75,35 +77,45 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
     true
   end
 
+  def get_router(tgt_label)
+    label_router = if tgt_label.nil? || tgt_label.empty?
+            router
+        else
+            event_emitter_router(tgt_label)
+        end
+    #log.trace "Got router for #{tgt_label}: #{!label_router.nil?}"
+    return label_router
+  end
+
   def process(tag, es)
     placeholder = get_placeholder(tag)
-    if @batch_mode
-      new_event_streams = Hash.new {|h, k| h[k] = Fluent::MultiEventStream.new }
-      es.each do |time, record|
-        rewrited_tag = rewrite_tag(tag, record, placeholder)
-        if rewrited_tag.nil? || tag == rewrited_tag
-          log.trace("rewrite_tag_filter: tag has not been rewritten", record)
-          next
-        end
-        new_event_streams[rewrited_tag].add(time, record)
+    new_event_streams =  Hash.new {|hh, kk| hh[kk] = Hash.new {|h, k| h[k] = Fluent::MultiEventStream.new }}if @batch_mode
+
+    es.each do |time, record|
+      rewrited_tag, rewrited_label  = rewrite_tag(tag, record, placeholder)
+      if (rewrited_tag.nil? || tag == rewrited_tag) && rewrited_label.nil?
+        log.trace("rewrite_tag_filter: tag has not been rewritten", record)
+        next
       end
-      new_event_streams.each do |rewrited_tag, new_es|
-        router.emit_stream(rewrited_tag, new_es)
+      rewrited_tag = tag if rewrited_tag.nil?
+      if new_event_streams.nil?
+        get_router(rewrited_label).emit(rewrited_tag, time, record)
+      else
+        new_event_streams[rewrited_label][rewrited_tag].add(time, record)
       end
-    else
-      es.each do |time, record|
-        rewrited_tag = rewrite_tag(tag, record, placeholder)
-        if rewrited_tag.nil? || tag == rewrited_tag
-          log.trace("rewrite_tag_filter: tag has not been rewritten", record)
-          next
+    end
+    if !new_event_streams.nil?
+      new_event_streams.each do |rewrited_label, label_event_streams |
+        labeled_router = get_router(rewrited_label)
+        label_event_streams.each do |rewrited_tag, new_es|
+            labeled_router.emit_stream(rewrited_tag, new_es)
         end
-        router.emit(rewrited_tag, time, record)
       end
     end
   end
 
   def rewrite_tag(tag, record, placeholder)
-    @rewriterules.each do |record_accessor, regexp, match_operator, rewritetag|
+    @rewriterules.each do |record_accessor, regexp, match_operator, rewritetag, rewritelabel|
       rewritevalue = record_accessor.call(record).to_s
       next if rewritevalue.empty? && match_operator != MATCH_OPERATOR_EXCLUDE
       last_match = regexp_last_match(regexp, rewritevalue)
@@ -119,9 +131,9 @@ class Fluent::Plugin::RewriteTagFilterOutput < Fluent::Plugin::Output
         log.warn "rewrite_tag_filter: unknown placeholder found. :placeholder=>#{$1} :tag=>#{tag} :rewritetag=>#{rewritetag}" unless placeholder.include?($1)
         placeholder[$1]
       end
-      return rewritetag
+      return rewritetag, rewritelabel
     end
-    return nil
+    return nil, nil
   end
 
   def regexp_last_match(regexp, rewritevalue)

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -346,6 +346,77 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
       assert_equal "com.example", events[0][0]
     end
 
+    test "get_router" do
+      conf = %[
+        <rule>
+          key key
+          pattern /^(odd|even)$/
+          tag $1
+          label new_label
+        </rule>
+        <rule>
+          key key
+          pattern /^(.*)$/
+          tag $1
+        </rule>
+      ]
+      time = event_time
+      d = create_driver(conf)
+      assert_equal(d.instance.router, d.instance.get_router(nil))
+      assert_equal(d.instance.router, d.instance.get_router(""))
+      new_label_router = d.instance.get_router("new_label")
+      refute_equal(d.instance.router, new_label_router)
+    end
+
+    test "relabel" do
+      conf = %[
+          emit_mode record
+          <rule>
+            key key
+            pattern /^(odd)$/
+            tag $1
+            label odd_label
+          </rule>
+          <rule>
+            key key
+            pattern /^(even)$/
+            tag ${tag}
+            label even_label
+          </rule>
+          <rule>
+            key key
+            pattern /^(.*)$/
+            tag $1
+          </rule>
+        ]
+        time = event_time
+        d = create_driver(conf)
+        # Router only called for default label
+        mock.proxy(d.instance.router).emit(anything, anything, anything).times(2)
+        mock.proxy(d.instance).get_router("odd_label").times(2)
+        mock.proxy(d.instance).get_router("even_label").times(2)
+        mock.proxy(d.instance).get_router(nil).times(2)
+        mock.proxy(d.instance.router).emit_stream(anything, anything).times(0)
+        d.run(default_tag: "input") do
+          d.feed([[time, { "key" => "odd", "message" => "message-1" }],
+                  [time, { "key" => "even", "message" => "message-2" }],
+                  [time, { "key" => "zero", "message" => "message-3" }],
+                  [time, { "key" => "odd", "message" => "message-4" }],
+                  [time, { "key" => "even", "message" => "message-5" }],
+                  [time, { "key" => "zero", "message" => "message-6" }]])
+        end
+        events = d.events
+        expected_events = [
+          ["odd", time, { "key" => "odd", "message" => "message-1" }],
+          ["input", time, { "key" => "even", "message" => "message-2" }],
+          ["zero", time, { "key" => "zero", "message" => "message-3" }],
+          ["odd", time, { "key" => "odd", "message" => "message-4" }],
+          ["input", time, { "key" => "even", "message" => "message-5" }],
+          ["zero", time, { "key" => "zero", "message" => "message-6" }],
+        ]
+        assert_equal(events, expected_events)
+    end
+
     sub_test_case "emit_mode" do
       test "record" do
         conf = %[

--- a/test/plugin/test_out_rewrite_tag_filter.rb
+++ b/test/plugin/test_out_rewrite_tag_filter.rb
@@ -389,32 +389,32 @@ class RewriteTagFilterOutputTest < Test::Unit::TestCase
             tag $1
           </rule>
         ]
-        time = event_time
-        d = create_driver(conf)
-        # Router only called for default label
-        mock.proxy(d.instance.router).emit(anything, anything, anything).times(2)
-        mock.proxy(d.instance).get_router("odd_label").times(2)
-        mock.proxy(d.instance).get_router("even_label").times(2)
-        mock.proxy(d.instance).get_router(nil).times(2)
-        mock.proxy(d.instance.router).emit_stream(anything, anything).times(0)
-        d.run(default_tag: "input") do
-          d.feed([[time, { "key" => "odd", "message" => "message-1" }],
-                  [time, { "key" => "even", "message" => "message-2" }],
-                  [time, { "key" => "zero", "message" => "message-3" }],
-                  [time, { "key" => "odd", "message" => "message-4" }],
-                  [time, { "key" => "even", "message" => "message-5" }],
-                  [time, { "key" => "zero", "message" => "message-6" }]])
-        end
-        events = d.events
-        expected_events = [
-          ["odd", time, { "key" => "odd", "message" => "message-1" }],
-          ["input", time, { "key" => "even", "message" => "message-2" }],
-          ["zero", time, { "key" => "zero", "message" => "message-3" }],
-          ["odd", time, { "key" => "odd", "message" => "message-4" }],
-          ["input", time, { "key" => "even", "message" => "message-5" }],
-          ["zero", time, { "key" => "zero", "message" => "message-6" }],
-        ]
-        assert_equal(events, expected_events)
+      time = event_time
+      d = create_driver(conf)
+      # Router only called for default label
+      mock.proxy(d.instance.router).emit(anything, anything, anything).times(2)
+      mock.proxy(d.instance).get_router("odd_label").times(2)
+      mock.proxy(d.instance).get_router("even_label").times(2)
+      mock.proxy(d.instance).get_router(nil).times(2)
+      mock.proxy(d.instance.router).emit_stream(anything, anything).times(0)
+      d.run(default_tag: "input") do
+        d.feed([[time, { "key" => "odd", "message" => "message-1" }],
+                [time, { "key" => "even", "message" => "message-2" }],
+                [time, { "key" => "zero", "message" => "message-3" }],
+                [time, { "key" => "odd", "message" => "message-4" }],
+                [time, { "key" => "even", "message" => "message-5" }],
+                [time, { "key" => "zero", "message" => "message-6" }]])
+      end
+      events = d.events
+      expected_events = [
+        ["odd", time, { "key" => "odd", "message" => "message-1" }],
+        ["input", time, { "key" => "even", "message" => "message-2" }],
+        ["zero", time, { "key" => "zero", "message" => "message-3" }],
+        ["odd", time, { "key" => "odd", "message" => "message-4" }],
+        ["input", time, { "key" => "even", "message" => "message-5" }],
+        ["zero", time, { "key" => "zero", "message" => "message-6" }],
+      ]
+      assert_equal(events, expected_events)
     end
 
     sub_test_case "emit_mode" do


### PR DESCRIPTION
To make this into a full fledged router, I am adding ability to specify per-rule label.

I wanted to open this to have someone review it to make sure this is a sane idea to begin with. I am relatively new to FluentD and wanted to make sure I am not breaking something I do not understand.

Core idea is to reduce number of plugins for routing by combing label and tag based routing rules in same config:

```
<match parsed.syslog.**>
  @type rewrite_tag_filter
  <rule>
    key         ident
    pattern  /^audit$/
    tag         audit.${tag}
    label      audit_log
  </rule>
  <rule>
    key         ident
    pattern  /^sudo$/
    tag         auth.${tag}
    label      auth
  </rule>
  <rule>
    key        ident
    pattern  /.*/
    tag         ${tag} ## keep tag the same
    label      default
  </rule>
</match>
```
Instead of having to do a whole slew of tag rewriting plugins plus relabel plugins.

This also allows rerouting of events to labels without modification of tag (by keeping tag same)

Let me know what you think