### PR TITLE
CI: Add Ruby 3.2, 3.1 and drop 2.6, 2.5

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         os:
           - ubuntu-latest
         experimental: [false]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         os:
           - macOS-latest
         experimental: [false]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         os:
           - windows-latest
         experimental: [false]


### PR DESCRIPTION
Ruby 2.7 is EOL since 2023-04.

In addition, the next [td-agent](https://github.com/fluent/fluent-package-builder) will embed Ruby 3.2.

So we should update Ruby version of the CI.